### PR TITLE
Fix for segfault on Gtk.mainQuit

### DIFF
--- a/src/internal/PersistentObjectStore.h
+++ b/src/internal/PersistentObjectStore.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <map>
+
+namespace gir {
+
+template<class KeyType, class PersistentType> class PersistentObjectStore {
+public:
+    PersistentObjectStore() = default;
+
+    ~PersistentObjectStore() {
+        for (auto &keyValue : persistentObjects)
+            keyValue.second.Empty();  // Disposes of the persistent's handle
+    };
+
+    PersistentType &at(const KeyType &key) {
+        return persistentObjects.at(key);
+    }
+
+    void insert(const std::pair<const KeyType, PersistentType> pair) {
+        persistentObjects.insert(pair);
+    }
+
+    bool exists(const KeyType &key) {
+        return persistentObjects.count(key) > 0;
+    }
+
+private:
+    std::map<KeyType, PersistentType> persistentObjects;
+};
+
+}

--- a/src/types/struct.cpp
+++ b/src/types/struct.cpp
@@ -16,7 +16,7 @@ namespace gir {
 using namespace v8;
 using namespace std;
 
-map<GType, ManagedPersistentFunctionTemplate> GIRStruct::prepared_js_classes;
+PersistentObjectStore<GType, PersistentFunctionTemplate> GIRStruct::prepared_js_classes;
 
 gpointer GIRStruct::get_native_ptr() {
     return this->boxed_c_structure;
@@ -25,8 +25,8 @@ gpointer GIRStruct::get_native_ptr() {
 Local<Value> GIRStruct::from_existing(gpointer c_structure, GIStructInfo *info) {
     GType gtype = g_registered_type_info_get_g_type(info);
     Local<Function> klass;
-    if (GIRStruct::prepared_js_classes.count(gtype) == 1) {
-        ManagedPersistentFunctionTemplate cached_js_class = GIRStruct::prepared_js_classes.at(gtype);
+    if (GIRStruct::prepared_js_classes.exists(gtype)) {
+        PersistentFunctionTemplate cached_js_class = GIRStruct::prepared_js_classes.at(gtype);
         auto function_template = Nan::New(cached_js_class);
         klass = function_template->GetFunction();
     } else {
@@ -71,7 +71,7 @@ Local<Function> GIRStruct::prepare(GIStructInfo *info) {
     // to the JS function (constructor)
     Local<FunctionTemplate> object_template = Nan::New<FunctionTemplate>(GIRStruct::constructor, struct_info_extern);
     GIRStruct::prepared_js_classes.insert(
-        make_pair(g_registered_type_info_get_g_type(info), ManagedPersistentFunctionTemplate(object_template)));
+            make_pair(g_registered_type_info_get_g_type(info), PersistentFunctionTemplate(object_template)));
 
     object_template->SetClassName(Nan::New(name).ToLocalChecked());
 

--- a/src/types/struct.cpp
+++ b/src/types/struct.cpp
@@ -16,7 +16,7 @@ namespace gir {
 using namespace v8;
 using namespace std;
 
-map<GType, PersistentFunctionTemplate> GIRStruct::prepared_js_classes;
+map<GType, ManagedPersistentFunctionTemplate> GIRStruct::prepared_js_classes;
 
 gpointer GIRStruct::get_native_ptr() {
     return this->boxed_c_structure;
@@ -26,7 +26,7 @@ Local<Value> GIRStruct::from_existing(gpointer c_structure, GIStructInfo *info) 
     GType gtype = g_registered_type_info_get_g_type(info);
     Local<Function> klass;
     if (GIRStruct::prepared_js_classes.count(gtype) == 1) {
-        PersistentFunctionTemplate cached_js_class = GIRStruct::prepared_js_classes.at(gtype);
+        ManagedPersistentFunctionTemplate cached_js_class = GIRStruct::prepared_js_classes.at(gtype);
         auto function_template = Nan::New(cached_js_class);
         klass = function_template->GetFunction();
     } else {
@@ -71,7 +71,7 @@ Local<Function> GIRStruct::prepare(GIStructInfo *info) {
     // to the JS function (constructor)
     Local<FunctionTemplate> object_template = Nan::New<FunctionTemplate>(GIRStruct::constructor, struct_info_extern);
     GIRStruct::prepared_js_classes.insert(
-        make_pair(g_registered_type_info_get_g_type(info), PersistentFunctionTemplate(object_template)));
+        make_pair(g_registered_type_info_get_g_type(info), ManagedPersistentFunctionTemplate(object_template)));
 
     object_template->SetClassName(Nan::New(name).ToLocalChecked());
 

--- a/src/types/struct.h
+++ b/src/types/struct.h
@@ -5,6 +5,7 @@
 #include <nan.h>
 #include <v8.h>
 #include <vector>
+#include <internal/PersistentObjectStore.h>
 #include "util.h"
 
 namespace gir {
@@ -12,8 +13,7 @@ namespace gir {
 using namespace v8;
 
 // Use the managed trait as this is for storing structs managed by Gtk main loop
-using ManagedPersistentFunctionTemplate
-                            = Nan::Persistent<FunctionTemplate, ManagedCopyablePersistentTraits<FunctionTemplate>>;
+using PersistentFunctionTemplate = Nan::Persistent<FunctionTemplate, CopyablePersistentTraits<FunctionTemplate>>;
 
 class GIRStruct;
 
@@ -25,7 +25,7 @@ public:
     static Local<Value> from_existing(gpointer boxed_c_structure, GIStructInfo *info);
 
 private:
-    static map<GType, ManagedPersistentFunctionTemplate> prepared_js_classes;
+    static PersistentObjectStore<GType, PersistentFunctionTemplate> prepared_js_classes;
 
     gpointer boxed_c_structure = nullptr;
     GIRInfoUniquePtr struct_info = nullptr;

--- a/src/types/struct.h
+++ b/src/types/struct.h
@@ -11,7 +11,9 @@ namespace gir {
 
 using namespace v8;
 
-using PersistentFunctionTemplate = Nan::Persistent<FunctionTemplate, CopyablePersistentTraits<FunctionTemplate>>;
+// Use the managed trait as this is for storing structs managed by Gtk main loop
+using ManagedPersistentFunctionTemplate
+                            = Nan::Persistent<FunctionTemplate, ManagedCopyablePersistentTraits<FunctionTemplate>>;
 
 class GIRStruct;
 
@@ -23,7 +25,7 @@ public:
     static Local<Value> from_existing(gpointer boxed_c_structure, GIStructInfo *info);
 
 private:
-    static map<GType, PersistentFunctionTemplate> prepared_js_classes;
+    static map<GType, ManagedPersistentFunctionTemplate> prepared_js_classes;
 
     gpointer boxed_c_structure = nullptr;
     GIRInfoUniquePtr struct_info = nullptr;

--- a/src/util.h
+++ b/src/util.h
@@ -21,6 +21,22 @@ struct GIBaseInfoDeleter {
 };
 
 /**
+ * This is a trait to be used when the object that is being held has copy semantics but its memory is
+ * manually or externally managed, for example with structs that the Gtk Main Loop controls. Persistent
+ * objects that have this trait will not have their handler reference reset on destruction. It is
+ * assumed the memory has been dealt with.
+ *
+ * @tparam T Object type that has this trait
+ */
+template<class T>
+struct ManagedCopyablePersistentTraits {
+    typedef v8::Persistent<T, ManagedCopyablePersistentTraits<T> > CopyablePersistent;
+    static const bool kResetInDestructor = false; // GtkStructs memory is managed by the Gtk Main Loop
+    template<class S, class M>
+    static V8_INLINE void Copy(const v8::Persistent<S, M>& source, CopyablePersistent* dest) { }
+};
+
+/**
  * This alias allows for a more readable way of wrapping a GIBaseInfo pointer
  * or some derivative (GICallableInfo, etc) in a std::unique_ptr with a custom
  * deleter that calls `g_base_info_unref`.

--- a/src/util.h
+++ b/src/util.h
@@ -21,22 +21,6 @@ struct GIBaseInfoDeleter {
 };
 
 /**
- * This is a trait to be used when the object that is being held has copy semantics but its memory is
- * manually or externally managed, for example with structs that the Gtk Main Loop controls. Persistent
- * objects that have this trait will not have their handler reference reset on destruction. It is
- * assumed the memory has been dealt with.
- *
- * @tparam T Object type that has this trait
- */
-template<class T>
-struct ManagedCopyablePersistentTraits {
-    typedef v8::Persistent<T, ManagedCopyablePersistentTraits<T> > CopyablePersistent;
-    static const bool kResetInDestructor = false; // GtkStructs memory is managed by the Gtk Main Loop
-    template<class S, class M>
-    static V8_INLINE void Copy(const v8::Persistent<S, M>& source, CopyablePersistent* dest) { }
-};
-
-/**
  * This alias allows for a more readable way of wrapping a GIBaseInfo pointer
  * or some derivative (GICallableInfo, etc) in a std::unique_ptr with a custom
  * deleter that calls `g_base_info_unref`.


### PR DESCRIPTION
Added a custom copy trait that does not reset memory on destruction. This stops segfaults when deleting cached/prepared Gtk Structs on the Gtk main loop quitting. This trait should only be used to hold memory that is manually cleaned up, which in this case is handled by Gtk itself.

This pull request is to fix issue #15 . Tested against the code snippets in that issue and against gtk.js in the examples which segfaulted on window close.

Hope it's up to scratch :)